### PR TITLE
Fix docker compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Bot:
 
 3. Next we write to the terminal at the root of the repository itself
 ```bash
-docker-compose up -d 
+docker compose up -d 
 ```
 	And we wait for the docker to finish deploying the bot.
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/878585d5-d366-4d8b-a18e-5d81ad8fb700)
`docker-compose` у меня не работает, но работает `docker compose`. Это опечатка? Или, может, в новых версиях они поменяли это, хз.